### PR TITLE
fixed state bug

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,9 +12,10 @@ function App() {
 
   return (
     <div>
+
       <Navbar searchTerm={searchTerm} setSearchTerm={setSearchTerm}/>
       <main className='container pt-5'>
-        <Outlet />
+        <Outlet context={searchTerm} />
       </main>
     <Footer />
      {/* </SearchContext.Provider> */}

--- a/client/src/api/RecipeDetailsAPI.tsx
+++ b/client/src/api/RecipeDetailsAPI.tsx
@@ -1,7 +1,7 @@
 const retrieveRecipeDetails = async (id: string) => {
     try {
       const response = await fetch(
-        `/recipe/${id}/information`,
+        `/recipes/${id}/information`,
       );
       // destructure response.  api call returns object with 1 key (results), whose value is the array of objects(recipes) we are inteerested in.
       const result = await response.json();

--- a/client/src/components/PaginatedList.tsx
+++ b/client/src/components/PaginatedList.tsx
@@ -20,17 +20,20 @@ const PaginatedList: React.FC<Props> = ({ items }) => {
   const indexOfLastItem = currentPage * itemsPerPage;
   const indexOfFirstItem = indexOfLastItem - itemsPerPage;
   const currentItems = items.slice(indexOfFirstItem, indexOfLastItem);
+  console.log(currentItems);
+  console.log(currentPage);
 
   // Function to handle page change
   const handleClick = (pageNumber: number) => {
     setCurrentPage(pageNumber);
   };
-
+console.log(items.length)
   // Generate page numbers
   const pageNumbers = [];
   for (let i = 1; i <= Math.ceil(items.length / itemsPerPage); i++) {
     pageNumbers.push(i);
   }
+  console.log(pageNumbers);
 
   return (
     <div>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -31,7 +31,7 @@ const router = createBrowserRouter([
         element: <SignUp />,
       },
       {
-        path: '/recipe',
+        path: '/recipes/:id/information',
         element: <Recipe />,
       },
       {

--- a/client/src/pages/Recipe.tsx
+++ b/client/src/pages/Recipe.tsx
@@ -1,9 +1,7 @@
 import { useState, useEffect } from "react";
-import ErrorPage from "./ErrorPage";
 import { retrieveRecipeDetails } from "../api/RecipeDetailsAPI";
+import ErrorPage from "./ErrorPage";
 import {useParams} from 'react-router-dom';
-// const params = new URLSearchParams(window.location.search);
-// const searchTerm = params.get('q');
 
 interface Recipe {
     image: string,
@@ -18,7 +16,9 @@ interface Ingredients {
 }
 
 const Recipe = (_props:any) => {
+  
     const {id} = useParams();
+    console.log(id)
     const [error, setError] = useState(false);
     const [recipe, setRecipe] = useState<Recipe>({
         image: '',

--- a/client/src/pages/Search.tsx
+++ b/client/src/pages/Search.tsx
@@ -2,13 +2,15 @@ import { useState, useEffect } from "react";
 import ErrorPage from "./ErrorPage";
 import { retrieveSearchResults } from "../api/SearchAPI";
 import PaginatedList from "../components/PaginatedList";
+import { useOutletContext } from "react-router-dom";
 
-const params = new URLSearchParams(window.location.search);
-const searchTerm = params.get('q');
+
+// const searchTerm = params.get('q');
 
 const Search = () => {
     const [recipes, setRecipes] = useState([])
     const [error, setError] = useState(false);
+    const value:string = useOutletContext();
 
     useEffect (() => {
         fetchSearchResults()
@@ -16,7 +18,7 @@ const Search = () => {
 
     const fetchSearchResults = async () => {
         try {
-            const data = await retrieveSearchResults(searchTerm as string);
+            const data = await retrieveSearchResults(value as string);
             setRecipes(data);
         } catch (err) {
             console.error('Failed to retrieve tickets:', err);
@@ -30,7 +32,7 @@ const Search = () => {
 
     return (
         <div className="search">
-            <h2>Search results for {searchTerm}</h2>
+            <h2>Search results for {value}</h2>
             <PaginatedList items={recipes}/>
         </div>
     );


### PR DESCRIPTION
Fixed state bug (navigation pane talking to search using props/context) with the help of the tutor.  We also found a few other bugs along the way:

- our backend is only passing 10 recipe results to the front end.  We confirmed that the front end is not limiting it the result amount.  Nick, can you please check into why this might be? does it have to do with the membership/api key provided?  or is it something else?
- the search page cannot perform another search after the original one.  this is what he called an "edge case" and probably won't take away from our project since we have the proof of concept complete.
- deleting params from the search bar to get back home causes search results to stay on the page.  Not sure why, probably due to the above error.  We need to create a link to get back home from the result page, my suggestion would be to convert our logo and title in navigation to a link. maybe this would solve the problem.